### PR TITLE
Add time range slider to Map component

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "@tabler/icons-react": "^3.10.0",
+    "@types/lodash": "^4.17.7",
     "dayjs": "^1.11.11",
     "home-assistant-js-websocket": "^9.4.0",
     "leaflet": "^1.9.4",
+    "lodash": "^4.17.21",
     "mqtt": "^5.8.0",
     "next": "14.2.5",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,18 +8,21 @@ dependencies:
   '@tabler/icons-react':
     specifier: ^3.10.0
     version: 3.10.0(react@18.3.1)
+  '@types/lodash':
+    specifier: ^4.17.7
+    version: 4.17.7
   dayjs:
     specifier: ^1.11.11
     version: 1.11.11
-  dotenv:
-    specifier: ^16.4.5
-    version: 16.4.5
   home-assistant-js-websocket:
     specifier: ^9.4.0
     version: 9.4.0
   leaflet:
     specifier: ^1.9.4
     version: 1.9.4
+  lodash:
+    specifier: ^4.17.21
+    version: 4.17.21
   mqtt:
     specifier: ^5.8.0
     version: 5.8.0
@@ -358,6 +361,10 @@ packages:
     dependencies:
       '@types/geojson': 7946.0.14
     dev: true
+
+  /@types/lodash@4.17.7:
+    resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
+    dev: false
 
   /@types/node@20.14.10:
     resolution: {integrity: sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==}
@@ -965,11 +972,6 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
-
-  /dotenv@16.4.5:
-    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
-    engines: {node: '>=12'}
-    dev: false
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2065,6 +2067,10 @@ packages:
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: false
 
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -8,6 +8,8 @@ import Image from "next/image";
 
 import strikeIcon from "../app/strike.png";
 import dayjs from "dayjs";
+import { memoize } from "lodash";
+import timeAgo from "dayjs/plugin/relativeTime";
 import {
   NEXT_PUBLIC_API_URL_WEBSOCKET,
   NEXT_PUBLIC_HOME_LAT,
@@ -16,42 +18,76 @@ import {
 } from "@/constants";
 import { useEffect, useState } from "react";
 
+dayjs.extend(timeAgo, {
+  thresholds: [
+    { l: "s", r: 1 },
+    { l: "m", r: 1 },
+    { l: "mm", r: 600, d: "minute" },
+  ],
+});
+
+const showTimeRange = 60; // seconds
+
 const mapCenter = [NEXT_PUBLIC_HOME_LAT, NEXT_PUBLIC_HOME_LONG] as [
   number,
   number
 ];
 
-const Strike = ({
-  strike,
-  timeRange,
-}: {
-  strike: StrikeEntity;
-  timeRange: number;
-}) => {
-  const now = dayjs();
-  const relevancy =
-    (1 + dayjs(strike.last_changed).diff(now, "minute") / 10) * timeRange;
+const Strike = memoize(
+  ({ strike, timeRange }: { strike: StrikeEntity; timeRange: number }) => {
+    const now = dayjs();
+    const timeRangeFinal = (timeRange / 100) * showTimeRange;
+    const relevant = dayjs(now).isBefore(
+      dayjs(strike.last_changed).add(timeRangeFinal, "minute")
+    );
 
-  return (
-    <Marker
-      key={strike.entity_id}
-      position={[strike.attributes.latitude, strike.attributes.longitude]}
-    >
-      <Image
-        src={strikeIcon}
-        alt=""
-        height={relevancy !== 0 ? 12 * relevancy : 1}
-        width={relevancy !== 0 ? 12 * relevancy : 1}
-        style={{
-          opacity: 1 * relevancy,
-        }}
-        className={`absolute markerAppear z-20 h-[${12 * relevancy}px] w-[${
-          12 * relevancy
-        }px] rounded-full`}
-      />
-    </Marker>
-  );
-};
+    const hoverData = (
+      <div className="group-hover:opacity-100 pointer-events-none opacity-0 absolute z-25 top-[-40px] h-[30px] left-[-41px] w-[100px] text-center bg-slate-900/50 text-white backdrop-blur-lg rounded-lg p-2">
+        {dayjs(strike.last_changed).fromNow()}
+      </div>
+    );
+
+    return relevant ? (
+      <Marker
+        key={strike.entity_id}
+        position={[strike.attributes.latitude, strike.attributes.longitude]}
+      >
+        <div className="group">
+          <Image
+            src={strikeIcon}
+            title={dayjs(strike.last_changed).fromNow()}
+            alt={dayjs(strike.last_changed).fromNow()}
+            height={18}
+            width={18}
+            className="absolute markerAppear z-20 h-[18px] w-[18px] rounded-full"
+          />
+          {hoverData}
+        </div>
+      </Marker>
+    ) : (
+      <Marker
+        key={strike.entity_id}
+        position={[strike.attributes.latitude, strike.attributes.longitude]}
+      >
+        <div className="group">
+          <Image
+            src={strikeIcon}
+            title={dayjs(strike.last_changed).fromNow()}
+            alt={dayjs(strike.last_changed).fromNow()}
+            height={8}
+            width={8}
+            style={{
+              opacity: 1,
+              filter: "saturate(0%)",
+            }}
+            className="absolute markerAppear z-20 h-[8px] w-[8px] rounded-full"
+          />
+          {hoverData}
+        </div>
+      </Marker>
+    );
+  }
+);
 
 export const Map = ({
   baseStrikesData,
@@ -62,7 +98,7 @@ export const Map = ({
 }) => {
   const [connected, setConnected] = useState<boolean>(false);
   const [strikes, setStrikes] = useState<StrikeEntity[]>(baseStrikesData);
-  const [timeRange, setTimeRange] = useState<number>(1);
+  const [timeRange, setTimeRange] = useState<number>(100);
 
   useEffect(() => {
     const ws = new WebSocket(NEXT_PUBLIC_API_URL_WEBSOCKET as string);
@@ -111,21 +147,24 @@ export const Map = ({
         <p>Lightning count: {strikes.length}</p>
         <p>Backend: {connected ? "Connected" : "Not connected"}</p>
         {/* slider */}
-        <label htmlFor="range">Time range:</label>
+        <label htmlFor="range">Time range (% of 1h):</label>
         <input
           type="range"
           min="0"
-          max="10"
+          max="100"
           step="1"
-          value={timeRange * 10}
+          value={timeRange}
           onChange={(e) => {
-            setTimeRange(parseInt(e.target.value) / 10);
+            setTimeRange(parseFloat(e.target.value));
           }}
         />
+        <p>
+          Showing last: {Math.ceil((timeRange / 100) * showTimeRange)} minutes
+        </p>
       </div>
       <MapContainer
         center={mapCenter}
-        zoom={7}
+        zoom={12}
         scrollWheelZoom={true}
         style={{ height: "100vh", width: "100vw", zIndex: 0 }}
         fadeAnimation={false}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -21,9 +21,16 @@ const mapCenter = [NEXT_PUBLIC_HOME_LAT, NEXT_PUBLIC_HOME_LONG] as [
   number
 ];
 
-const Strike = ({ strike }: { strike: StrikeEntity }) => {
+const Strike = ({
+  strike,
+  timeRange,
+}: {
+  strike: StrikeEntity;
+  timeRange: number;
+}) => {
   const now = dayjs();
-  const relevancy = 1 + dayjs(strike.last_changed).diff(now, "minute") / 10;
+  const relevancy =
+    (1 + dayjs(strike.last_changed).diff(now, "minute") / 10) * timeRange;
 
   return (
     <Marker
@@ -55,6 +62,7 @@ export const Map = ({
 }) => {
   const [connected, setConnected] = useState<boolean>(false);
   const [strikes, setStrikes] = useState<StrikeEntity[]>(baseStrikesData);
+  const [timeRange, setTimeRange] = useState<number>(1);
 
   useEffect(() => {
     const ws = new WebSocket(NEXT_PUBLIC_API_URL_WEBSOCKET as string);
@@ -102,6 +110,18 @@ export const Map = ({
         <p>Updated at: {updatedAt}</p>
         <p>Lightning count: {strikes.length}</p>
         <p>Backend: {connected ? "Connected" : "Not connected"}</p>
+        {/* slider */}
+        <label htmlFor="range">Time range:</label>
+        <input
+          type="range"
+          min="0"
+          max="10"
+          step="1"
+          value={timeRange * 10}
+          onChange={(e) => {
+            setTimeRange(parseInt(e.target.value) / 10);
+          }}
+        />
       </div>
       <MapContainer
         center={mapCenter}
@@ -119,7 +139,11 @@ export const Map = ({
         <MarkerLayer>
           <MarkerClusterGroup chunkedLoading>
             {strikes.map((strike) => (
-              <Strike key={strike.entity_id} strike={strike} />
+              <Strike
+                key={strike.entity_id}
+                strike={strike}
+                timeRange={timeRange}
+              />
             ))}
           </MarkerClusterGroup>
         </MarkerLayer>


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a time range slider to the Map component, enabling users to adjust the relevancy of lightning strikes based on a selected time range. The Strike component has been updated to incorporate this time range in its relevancy calculation.

- **New Features**:
    - Introduced a time range slider to the Map component, allowing users to adjust the relevancy of strikes based on a selected time range.
- **Enhancements**:
    - Updated the Strike component to factor in the time range when calculating the relevancy of strikes.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added a slider to adjust the time range for viewing strike relevancy on the map.
  - Enhanced the `Strike` component to improve rendering efficiency and dynamic control based on the specified time frame.
- **Improvements**
  - Increased map zoom level for a more detailed view of strike locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->